### PR TITLE
Upgrading node version to 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG RELEASE
 
 # Install node.js and yarn
 RUN rm -rf /var/lib/apt/lists/*
-RUN curl -sL https://deb.nodesource.com/setup_8.x > node_install.sh
+RUN curl -sL https://deb.nodesource.com/setup_10.x > node_install.sh
 RUN chmod +x ./node_install.sh
 RUN ./node_install.sh
 RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
Considering AWS is deprecating node 8 on their lambda functions, could we update this to use node 10?