### PR TITLE
Bump serverless framework version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ env:
   global:
     # RELEASE contains the serverless release to build
     # Ref: https://github.com/serverless/serverless/releases
-    - RELEASE=2.19.0
+    - RELEASE=2.43.1


### PR DESCRIPTION
Small PR to update serverless framework to the latest version.

The current version is already 4 months old.

Thanks in advance for merging this :slightly_smiling_face: