### PR TITLE
Bump serverless framework to 2.69.1 (released in 2021-12-15)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ env:
   global:
     # RELEASE contains the serverless release to build
     # Ref: https://github.com/serverless/serverless/releases
-    - RELEASE=2.43.1
+    - RELEASE=2.69.1


### PR DESCRIPTION
Update serverless framework to the latest version.
